### PR TITLE
Add submission relationships to user and challenge models

### DIFF
--- a/app/models/challenge.py
+++ b/app/models/challenge.py
@@ -1,5 +1,8 @@
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Column, Integer, String, Text, Boolean, ForeignKey, DateTime, func
 from sqlalchemy.orm import relationship
+
 from app.database import Base
 
 # NOTE: these imports are only for type/relationship wiring; no schema changes
@@ -8,6 +11,9 @@ from app.database import Base
 # - app/models/hint.py defines Hint with back_populates="challenge"
 from app.models.challenge_tag import ChallengeTag  # provides .tag and challenge_id FK
 from app.models.hint import Hint                   # provides text/penalty/order_index and challenge_id FK
+
+if TYPE_CHECKING:
+    from app.models.submission import Submission
 
 
 class Challenge(Base):
@@ -45,6 +51,8 @@ class Challenge(Base):
         cascade="all, delete-orphan",
         lazy="selectin",
     )
+
+    submissions = relationship("Submission", back_populates="challenge", lazy="selectin")
 
     # OPTIONAL: if you have a parent->children unlock chain:
     # children = relationship("Challenge", remote_side=[id])

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,6 +1,12 @@
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func
 from sqlalchemy.orm import relationship
+
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.submission import Submission
 
 class User(Base):
     __tablename__ = "users"
@@ -16,6 +22,12 @@ class User(Base):
     created_at = Column(DateTime, default=func.now())
 
     team = relationship("Team", back_populates="members", foreign_keys=[team_id])
+    submissions = relationship("Submission", back_populates="user", lazy="selectin")
 
     # NEW: if user is leader of a team
-    leading_team = relationship("Team", back_populates="leader", uselist=False, foreign_keys="Team.leader_id")
+    leading_team = relationship(
+        "Team",
+        back_populates="leader",
+        uselist=False,
+        foreign_keys="Team.leader_id",
+    )


### PR DESCRIPTION
## Summary
- add a submissions relationship to the User model so Submission.back_populates resolves
- add a submissions relationship to the Challenge model with selectin loading
- gate Submission imports behind TYPE_CHECKING to avoid circular dependencies and tidy the existing relationship definition

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000 *(fails: missing aiosqlite driver; dependency install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc407909c832e9c22facc8b0bc393