### PR TITLE
Convert competition routes to async SQLAlchemy usage

### DIFF
--- a/app/routes/competition.py
+++ b/app/routes/competition.py
@@ -1,34 +1,40 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.models.competition import Competition
 from app.schemas import CompetitionCreate, CompetitionOut
 router = APIRouter(prefix="/competitions", tags=["competitions"])
 
 @router.post("/", response_model=CompetitionOut)
-def create_competition(comp: CompetitionCreate, db: Session = Depends(get_db)):
+async def create_competition(
+    comp: CompetitionCreate, db: AsyncSession = Depends(get_db)
+):
     db_comp = Competition(**comp.dict())
     db.add(db_comp)
-    db.commit()
-    db.refresh(db_comp)
+    await db.commit()
+    await db.refresh(db_comp)
     return db_comp
 
 @router.get("/", response_model=list[CompetitionOut])
-def get_all(db: Session = Depends(get_db)):
-    return db.query(Competition).all()
+async def get_all(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Competition))
+    return result.scalars().all()
 
 @router.get("/{id}", response_model=CompetitionOut)
-def get_by_id(id: int, db: Session = Depends(get_db)):
-    comp = db.query(Competition).filter_by(id=id).first()
+async def get_by_id(id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Competition).where(Competition.id == id))
+    comp = result.scalars().first()
     if not comp:
         raise HTTPException(404, "Competition not found")
     return comp
 
 @router.delete("/{id}")
-def delete_competition(id: int, db: Session = Depends(get_db)):
-    comp = db.query(Competition).filter_by(id=id).first()
+async def delete_competition(id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Competition).where(Competition.id == id))
+    comp = result.scalars().first()
     if not comp:
         raise HTTPException(404, "Competition not found")
-    db.delete(comp)
-    db.commit()
+    await db.delete(comp)
+    await db.commit()
     return {"message": "Deleted"}


### PR DESCRIPTION
## Summary
- convert competition routes to async endpoints using AsyncSession dependencies
- replace deprecated ORM query patterns with select/execute usage and async commits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcc411bd68832eb39783c6959be826