### PR TITLE
Support role-based admin checks for admin challenge routes

### DIFF
--- a/app/routes/admin_challenges.py
+++ b/app/routes/admin_challenges.py
@@ -17,8 +17,18 @@ from app.schemas import (
 admin = APIRouter(prefix="/admin/challenges", tags=["Admin: Challenges"])
 
 def _is_admin(user: User) -> bool:
-    # Adjust to your project (e.g., user.role == "admin")
-    return bool(getattr(user, "is_admin", False) or getattr(user, "is_superuser", False))
+    """Return True when the current user should be treated as an admin."""
+
+    role = getattr(user, "role", None)
+    if isinstance(role, str) and role.lower() == "admin":
+        return True
+
+    # Legacy flags (older deployments may still rely on these attributes).
+    for legacy_flag in ("is_admin", "is_superuser"):
+        if getattr(user, legacy_flag, False):
+            return True
+
+    return False
 
 async def require_admin(user: User = Depends(get_current_user)) -> User:
     if not _is_admin(user):

--- a/tests/test_admin_challenges_access.py
+++ b/tests/test_admin_challenges_access.py
@@ -1,0 +1,66 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+if "aiosqlite" not in sys.modules:
+    import sqlite3
+
+    aiosqlite_stub = types.ModuleType("aiosqlite")
+
+    async def _connect(*args, **kwargs):  # pragma: no cover - used only if someone hits the DB
+        raise RuntimeError("aiosqlite is not installed in the test environment")
+
+    aiosqlite_stub.connect = _connect
+    for attr in (
+        "Error",
+        "Warning",
+        "InterfaceError",
+        "DatabaseError",
+        "InternalError",
+        "OperationalError",
+        "ProgrammingError",
+        "IntegrityError",
+        "DataError",
+        "NotSupportedError",
+    ):
+        setattr(aiosqlite_stub, attr, getattr(sqlite3, attr))
+
+    aiosqlite_stub.sqlite_version = sqlite3.sqlite_version
+    aiosqlite_stub.sqlite_version_info = sqlite3.sqlite_version_info
+
+    sys.modules["aiosqlite"] = aiosqlite_stub
+
+from app.routes.admin_challenges import require_admin  # noqa: E402
+
+
+def test_require_admin_allows_role_admin():
+    admin_user = SimpleNamespace(role="admin")
+
+    async def _run():
+        result = await require_admin(user=admin_user)
+        return result
+
+    result = asyncio.run(_run())
+    assert result is admin_user
+
+
+def test_require_admin_blocks_non_admin():
+    regular_user = SimpleNamespace(role="player")
+
+    async def _run():
+        try:
+            await require_admin(user=regular_user)
+        except HTTPException as exc:
+            return exc
+        return None
+
+    error = asyncio.run(_run())
+    assert isinstance(error, HTTPException)
+    assert error.status_code == 403
+    assert "Admin only" in error.detail


### PR DESCRIPTION
## Summary
- treat users with the `admin` role as administrators when guarding the admin challenge routes while preserving legacy boolean fallbacks
- add regression tests that confirm the `require_admin` dependency allows admins and blocks non-admins

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc40c58c8832e8906a13a376a7c07