### PR TITLE
Fix missing imports in auth route module

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,4 +1,10 @@
 
+import hashlib
+import hmac
+import os
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 


### PR DESCRIPTION
## Summary
- add the missing FastAPI router and dependency imports used in the auth routes
- include the required standard-library helpers for hashing and secure comparisons

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000 *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68dccd79af74832e8cfa3fdcc054259c